### PR TITLE
Fix Silica on CC1.74

### DIFF
--- a/src/classes/Application.lua
+++ b/src/classes/Application.lua
@@ -59,7 +59,7 @@ function Application.load( path )
 	loadClass = function( _path, content )
 		local name = fs.getName( _path )
 		if not loaded[name] then
-			local f, err = loadfile( _path, name )
+			local f, err = loadfile( _path )
 			if err then error( err, 0 ) end
 			local ok, err = pcall( f )
 			if err then error( err, 0 ) end


### PR DESCRIPTION
Loadfile before CC1.74 doesn't take a second argument anyway

And loadfile CC1.74 and after takes a table or nil, not a string.